### PR TITLE
Allow arguments to be passed through to gmxapi

### DIFF
--- a/run_brer/metadata.py
+++ b/run_brer/metadata.py
@@ -111,7 +111,6 @@ class MetaData(ABC):
 
         Returns
         -------
-        type
             The value of the parameter associated with the key.
         """
         return self._metadata[key]
@@ -171,7 +170,7 @@ class MultiMetaData(ABC):
         list
             a list of names
         """
-        return self.__names
+        return list(self.__names)
 
     @names.setter
     def names(self, names: list):
@@ -181,7 +180,7 @@ class MultiMetaData(ABC):
         ----------
         names : list
         """
-        self.__names = names
+        self.__names = list(names)
 
     @names.getter
     def names(self):
@@ -201,7 +200,7 @@ class MultiMetaData(ABC):
             if not self._metadata_list:
                 raise IndexError('Must import a list of metadata before retrieving names')
             self.__names = [metadata.name for metadata in self._metadata_list]
-        return self.__names
+        return list(self.__names)
 
     def add_metadata(self, metadata: MetaData):
         """Appends new MetaData object to self._metadata.
@@ -283,7 +282,7 @@ class MultiMetaData(ABC):
         """
         # TODO: decide on expected behavior here if there's a pre-existing list of data. For now, overwrite
         self._metadata_list = []
-        self._names = []
+        self.__names = []
         data = json.load(open(filename, 'r'))
         for name, metadata in data.items():
             self.__names.append(name)

--- a/run_brer/tests/test_metadata.py
+++ b/run_brer/tests/test_metadata.py
@@ -28,7 +28,7 @@ def test_multi_metadata(tmpdir):
     metadata.set_requirements(["param1", "param2"])
 
     with pytest.raises(IndexError):
-        multi.names
+        assert multi.names
     with pytest.raises(IndexError):
         multi.name_to_id("random name")
 

--- a/run_brer/tests/test_run_brer.py
+++ b/run_brer/tests/test_run_brer.py
@@ -1,7 +1,7 @@
 import run_brer
-import pytest
 import sys
 
 
 def test_run_brer_imported():
+    assert run_brer
     assert "run_brer" in sys.modules

--- a/run_brer/tests/test_run_config.py
+++ b/run_brer/tests/test_run_config.py
@@ -1,6 +1,8 @@
 import contextlib
 import os
 
+import pytest
+
 from run_brer.run_config import RunConfig
 
 
@@ -25,6 +27,8 @@ def test_run_config(tmpdir, data_dir):
         os.makedirs("{}/mem_{}".format(tmpdir, config_params["ensemble_num"]))
         rc = RunConfig(**config_params)
         rc.run_data.set(A=5, tau=0.1, tolerance=100, num_samples=2, sample_period=0.1, production_time=0.2)
+        rc.run(threads=2)
         rc.run()
-        rc.run()
-        rc.run()
+        with pytest.raises(TypeError):
+            rc.run(end_time=1.0)
+        rc.run(max_hours=0.1)

--- a/run_brer/tests/test_run_config.py
+++ b/run_brer/tests/test_run_config.py
@@ -1,35 +1,30 @@
-from run_brer.run_config import RunConfig
-import pytest
+import contextlib
 import os
 
-
-def test_run_config(tmpdir, data_dir, raw_pair_data):
-    current_dir = os.getcwd()
-    config_params = {
-        "tpr": "{}/topol.tpr".format(data_dir),
-        "ensemble_num": 1,
-        "ensemble_dir": tmpdir,
-        "pairs_json": "{}/pair_data.json".format(data_dir)
-    }
-    os.makedirs("{}/mem_{}".format(tmpdir, config_params["ensemble_num"]))
-    rc = RunConfig(**config_params)
-    rc.run_data.set(A=5, tau=0.1, tolerance=100, num_samples=2, sample_period=0.1, production_time=0.2)
-    rc.run()
-    rc.run()
-    rc.run()
-    os.chdir(current_dir)
+from run_brer.run_config import RunConfig
 
 
-# def test_converge(tmpdir, data_dir, raw_pair_data):
-#     current_dir = os.getcwd()
-#     config_params = {
-#         "tpr": "{}/topol.tpr".format(data_dir),
-#         "ensemble_num": 1,
-#         "ensemble_dir": tmpdir,
-#         "pairs_json": "{}/pair_data.json".format(data_dir)
-#     }
-#     os.makedirs("{}/mem_{}".format(tmpdir, config_params["ensemble_num"]))
-#     rc = RunConfig(**config_params)
-#     rc.run_data.set(A=5, tau=0.1, tolerance=100, num_samples=2, sample_period=0.1, production_time=0.2)
-#     rc.run()
-#     os.chdir(current_dir)
+@contextlib.contextmanager
+def working_directory_fence():
+    """Ensure restoration of working directory when leaving context manager."""
+    wd = os.getcwd()
+    try:
+        yield wd
+    finally:
+        os.chdir(wd)
+
+
+def test_run_config(tmpdir, data_dir):
+    with working_directory_fence():
+        config_params = {
+            "tpr": "{}/topol.tpr".format(data_dir),
+            "ensemble_num": 1,
+            "ensemble_dir": tmpdir,
+            "pairs_json": "{}/pair_data.json".format(data_dir)
+        }
+        os.makedirs("{}/mem_{}".format(tmpdir, config_params["ensemble_num"]))
+        rc = RunConfig(**config_params)
+        rc.run_data.set(A=5, tau=0.1, tolerance=100, num_samples=2, sample_period=0.1, production_time=0.2)
+        rc.run()
+        rc.run()
+        rc.run()

--- a/run_brer/tests/test_run_data.py
+++ b/run_brer/tests/test_run_data.py
@@ -2,7 +2,7 @@
 
 import pytest
 from run_brer.run_data import GeneralParams, PairParams, RunData
-from run_brer.pair_data import MultiPair, PairData
+from run_brer.pair_data import PairData
 
 
 def test_general_parameters():
@@ -55,6 +55,8 @@ def test_run_data(tmpdir, raw_pair_data):
 
     assert not rd.general_params.get_missing_keys()
 
+    # Get an arbitrary but valid name.
+    name = tuple(raw_pair_data.keys())[-1]
     # Test the setting function
     with pytest.raises(ValueError):
         rd.set(tau=0.1, name=name)


### PR DESCRIPTION
Allow run time GROMACS simulator arguments to be passed through run_brer to gmxapi.

Let `RunConfig.run(**kwargs)` pass key word arguments to `from_tpr()` in all run_brer phases.

Additional tidying:
* Resolve some warnings and potential logic errors.
* Minor clean-up to test_run_config.py.

Fixes #7 
Fixes #13 