### PR TITLE
Allow input file to be overridden in `run()`

### DIFF
--- a/run_brer/tests/test_run_config.py
+++ b/run_brer/tests/test_run_config.py
@@ -27,8 +27,17 @@ def test_run_config(tmpdir, data_dir):
         os.makedirs("{}/mem_{}".format(tmpdir, config_params["ensemble_num"]))
         rc = RunConfig(**config_params)
         rc.run_data.set(A=5, tau=0.1, tolerance=100, num_samples=2, sample_period=0.1, production_time=0.2)
+
+        # Training phase.
+        # Include a test for kwarg handling.
         rc.run(threads=2)
+
+        # Convergence phase.
         rc.run()
+
+        # Production phase.
         with pytest.raises(TypeError):
+            # Test handling of kwarg collisions.
             rc.run(end_time=1.0)
+        # Test another kwarg.
         rc.run(max_hours=0.1)

--- a/run_brer/tests/test_run_config.py
+++ b/run_brer/tests/test_run_config.py
@@ -1,5 +1,8 @@
 import contextlib
+import json
 import os
+import shutil
+import tempfile
 
 import pytest
 
@@ -29,15 +32,51 @@ def test_run_config(tmpdir, data_dir):
         rc.run_data.set(A=5, tau=0.1, tolerance=100, num_samples=2, sample_period=0.1, production_time=0.2)
 
         # Training phase.
+        assert rc.run_data.get('phase') == 'training'
         # Include a test for kwarg handling.
         rc.run(threads=2)
 
         # Convergence phase.
+        assert rc.run_data.get('phase') == 'convergence'
         rc.run()
 
         # Production phase.
+        assert rc.run_data.get('phase') == 'production'
         with pytest.raises(TypeError):
             # Test handling of kwarg collisions.
             rc.run(end_time=1.0)
+        # Note that rc.__production failed, but rc.run() will have changed directory.
+        # This is an unspecified side effect, but we can use it for some additional inspection.
+        assert len(os.listdir()) == 0
         # Test another kwarg.
         rc.run(max_hours=0.1)
+
+
+def test_production_bootstrap(tmpdir, data_dir):
+    with working_directory_fence():
+        config_params = {
+            "tpr": "{}/topol.tpr".format(data_dir),
+            "ensemble_num": 1,
+            "ensemble_dir": tmpdir,
+            "pairs_json": "{}/pair_data.json".format(data_dir)
+        }
+        os.makedirs("{}/mem_{}".format(tmpdir, config_params["ensemble_num"]))
+        rc = RunConfig(**config_params)
+        rc.run_data.set(A=5, tau=0.1, tolerance=100, num_samples=2, sample_period=0.1, production_time=0.2)
+
+        # Training phase.
+        rc.run()
+        # Convergence phase.
+        rc.run()
+
+        # Production phase.
+        # It is a little bit difficult to test that the production phase actually
+        # runs with a non-default TPR file.
+        # Warning: This may need some extra conditional logic to support more gmxapi versions.
+        assert rc.run_data.get('phase') == 'production'
+        with tempfile.TemporaryDirectory() as directory:
+            new_tpr = os.path.join(directory, 'tmp.tpr')
+            shutil.copy("{}/topol.tpr".format(data_dir), new_tpr)
+            gmxapi_context = rc.run(tpr_file=new_tpr, max_hours=0.01)
+        element = json.loads(gmxapi_context.work.elements['tpr_input'])
+        assert str(element['params']['input'][0]) == str(new_tpr)


### PR DESCRIPTION
Allow the production phase to be bootstrapped from a user-provided TPR file. 

This should allow us to handle the situation of incompatible checkpoint files when migrating convergence-phase data from one environment to another.

Refer to the updated test scripts for examples of usage and introspection.