### PR TITLE
Avoid premature advancement from production phase

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Build and test
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [ master ]
   pull_request:
-    branches: [ $default-branch ]
+    branches: [ master ]
 
 jobs:
   gmx2019:

--- a/run_brer/run_config.py
+++ b/run_brer/run_config.py
@@ -432,6 +432,10 @@ class RunConfig:
 
         tpr_list = list(self._tprs)
         tpr_list[self._rank] = self.__prep_input(tpr_file)
+        if tpr_file is not None:
+            # If bootstrap TPR is provided, we are not continuing from the
+            # convergence phase trajectory.
+            self.run_data.set(start_time=0.0)
 
         # Calculate the time (in ps) at which the trajectory for this BRER iteration should finish.
         # This should be: the end time of the convergence run + the amount of time for

--- a/run_brer/run_config.py
+++ b/run_brer/run_config.py
@@ -437,9 +437,9 @@ class RunConfig:
         # This should be: the end time of the convergence run + the amount of time for
         # production simulation (specified by the user).
         start_time = self.run_data.get('start_time')
-        end_time = self.run_data.get('production_time') + start_time
+        target_end_time = self.run_data.get('production_time') + start_time
 
-        md = from_tpr(tpr_list, end_time=end_time, append_output=False, **kwargs)
+        md = from_tpr(tpr_list, end_time=target_end_time, append_output=False, **kwargs)
 
         self.build_plugins(ProductionPluginConfig())
         for plugin in self.__plugins:

--- a/run_brer/run_data.py
+++ b/run_brer/run_data.py
@@ -12,12 +12,19 @@ class GeneralParams(MetaData):
     simulation.
 
     These include some of the "Voth" parameters: tau, A, tolerance
+
+    .. versionadded:: 2.0
+        The *end_time* parameter is only available with sufficiently recent versions of
+        https://github.com/kassonlab/brer_plugin (late 2.0 beta). Otherwise,
+        *end_time* will always be 0.0
+
     """
 
     def __init__(self):
         super().__init__('general')
         self.set_requirements([
             'A',
+            'end_time',
             'ensemble_num',
             'iteration',
             'num_samples',
@@ -37,13 +44,14 @@ class GeneralParams(MetaData):
     def get_defaults():
         return {
             'A': 50,
+            'end_time': 0.,
             'ensemble_num': 1,
             'iteration': 0,
             'num_samples': 50,
             'phase': 'training',
             'production_time': 10000,  # 10 ns
             'sample_period': 100,
-            'start_time': 0,
+            'start_time': 0.,
             'tau': 50,
             'tolerance': 0.25,
         }

--- a/run_brer/run_data.py
+++ b/run_brer/run_data.py
@@ -17,9 +17,16 @@ class GeneralParams(MetaData):
     def __init__(self):
         super().__init__('general')
         self.set_requirements([
-            'ensemble_num', 'iteration', 'phase', 'start_time', 'A', 'tau', 'tolerance',
+            'A',
+            'ensemble_num',
+            'iteration',
             'num_samples',
-            'sample_period', 'production_time'
+            'phase',
+            'production_time',
+            'sample_period',
+            'start_time',
+            'tau',
+            'tolerance',
         ])
 
     def set_to_defaults(self):

--- a/run_brer/tests/test_run_config.py
+++ b/run_brer/tests/test_run_config.py
@@ -54,7 +54,10 @@ def test_run_config(tmpdir, data_dir):
             "ensemble_dir": tmpdir,
             "pairs_json": "{}/pair_data.json".format(data_dir)
         }
-        os.makedirs("{}/mem_{}".format(tmpdir, config_params["ensemble_num"]))
+        os.makedirs(
+            "{}/mem_{}".format(tmpdir, config_params["ensemble_num"]),
+            exist_ok=True
+        )
         rc = RunConfig(**config_params)
         rc.run_data.set(A=5,
                         tau=0.1,
@@ -96,9 +99,8 @@ def test_run_config(tmpdir, data_dir):
 
 
 @with_mpi_only
-def test_mpi_ensemble(data_dir):
+def test_mpi_ensemble(tmpdir, data_dir):
     """Test a batch of multiple ensemble members in a single MPI context."""
-    test_dir = os.getcwd()
     with working_directory_fence():
         comm: MPI.Comm = MPI.COMM_WORLD
         rank: int = comm.Get_rank()
@@ -109,10 +111,13 @@ def test_mpi_ensemble(data_dir):
         config_params = {
             "tpr": tpr_list,
             "ensemble_num": None,
-            "ensemble_dir": test_dir,
+            "ensemble_dir": tmpdir,
             "pairs_json": "{}/pair_data.json".format(data_dir)
         }
-        # os.makedirs("{}/mem_{}".format(test_dir, config_params["ensemble_num"]))
+        os.makedirs(
+            "{}/mem_{}".format(tmpdir, config_params["ensemble_num"]),
+            exist_ok=True
+        )
         rc = RunConfig(**config_params)
         rc.run_data.set(A=5,
                         tau=0.1,

--- a/run_brer/tests/test_run_config.py
+++ b/run_brer/tests/test_run_config.py
@@ -95,6 +95,19 @@ def test_run_config(tmpdir, data_dir):
         # Test another kwarg.
         rc.run(max_hours=0.001)
         assert rc.run_data.get('phase') == 'production'
+
+        # Test the production phase bootstrapping option.
+        # It is a little difficult to test that the production phase actually
+        # runs with a non-default TPR file.
+        # Warning: This may need some extra conditional logic to support more gmxapi
+        # versions.
+        with tempfile.TemporaryDirectory() as directory:
+            new_tpr = os.path.join(directory, 'tmp.tpr')
+            shutil.copy("{}/topol.tpr".format(data_dir), new_tpr)
+            gmxapi_context = rc.run(tpr_file=new_tpr, max_hours=0.001)
+        element = json.loads(gmxapi_context.work.elements['tpr_input'])
+        assert str(element['params']['input'][0]) == str(new_tpr)
+        assert rc.run_data.get('phase') == 'production'
         assert rc.run_data.get('iteration') == 0
 
 
@@ -150,44 +163,3 @@ def test_mpi_ensemble(tmpdir, data_dir):
         if comm.Get_size() > 1:
             # TODO: Confirm that we actually ran different ensemble members.
             ...
-
-
-def test_production_bootstrap(tmpdir, data_dir):
-    with working_directory_fence():
-        config_params = {
-            "tpr": "{}/topol.tpr".format(data_dir),
-            "ensemble_num": 1,
-            "ensemble_dir": tmpdir,
-            "pairs_json": "{}/pair_data.json".format(data_dir)
-        }
-        os.makedirs("{}/mem_{}".format(tmpdir, config_params["ensemble_num"]))
-        rc = RunConfig(**config_params)
-        rc.run_data.set(A=5,
-                        tau=0.1,
-                        tolerance=100,
-                        num_samples=2,
-                        sample_period=0.1,
-                        production_time=0.2)
-
-        # Training phase.
-        assert rc.run_data.get('phase') == 'training'
-        rc.run()
-        # Convergence phase.
-        assert rc.run_data.get('phase') == 'convergence'
-        rc.run()
-
-        # Production phase.
-        # It is a little bit difficult to test that the production phase actually
-        # runs with a non-default TPR file.
-        # Warning: This may need some extra conditional logic to support more gmxapi
-        # versions.
-
-        # Test production bootstrap option.
-        # TODO: Merge with test_run_config once issue #19 is resolved.
-        assert rc.run_data.get('phase') == 'production'
-        with tempfile.TemporaryDirectory() as directory:
-            new_tpr = os.path.join(directory, 'tmp.tpr')
-            shutil.copy("{}/topol.tpr".format(data_dir), new_tpr)
-            gmxapi_context = rc.run(tpr_file=new_tpr, max_hours=0.001)
-        element = json.loads(gmxapi_context.work.elements['tpr_input'])
-        assert str(element['params']['input'][0]) == str(new_tpr)

--- a/run_brer/tests/test_run_config.py
+++ b/run_brer/tests/test_run_config.py
@@ -91,9 +91,8 @@ def test_run_config(tmpdir, data_dir):
         assert len(os.listdir()) == 0
         # Test another kwarg.
         rc.run(max_hours=0.001)
-        # TODO(#19): Confirm fix for production phase.
-        # assert rc.run_data.get('phase') == 'production'
-        # assert rc.run_data.get('iteration') == 0
+        assert rc.run_data.get('phase') == 'production'
+        assert rc.run_data.get('iteration') == 0
 
 
 @with_mpi_only

--- a/run_brer/tests/test_run_config.py
+++ b/run_brer/tests/test_run_config.py
@@ -26,7 +26,7 @@ except ImportError:
 #                             stderrToServer=True)
 
 with_mpi_only = pytest.mark.skipif(
-    MPI is None,
+    MPI is None or MPI.COMM_WORLD.Get_size() < 2,
     reason='This test requires mpi4py and a usable MPI environment.')
 
 # Try to get a reasonable number of threads to use.
@@ -145,7 +145,7 @@ def test_mpi_ensemble(tmpdir, data_dir):
         # inspection.
         assert len(os.listdir()) == 0
         # Test another kwarg.
-        rc.run(threads=4, max_hours=0.1)
+        rc.run(threads=4, max_hours=0.001)
 
         if comm.Get_size() > 1:
             # TODO: Confirm that we actually ran different ensemble members.


### PR DESCRIPTION
Check the start and end times of the production phase trajectory. Only advance if the requested *production_time* has been achieved.

Requires https://github.com/kassonlab/brer_plugin/pull/10 for full functionality. Otherwise, a warning is issued and the user may experience issue #19 