### PR TITLE
Update to GitHub Actions test configuration.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,8 +55,8 @@ jobs:
         . $HOME/venv/bin/activate
         pip install -r requirements.txt
         export PYTHON=$VIRTUAL_ENV/bin/python
-        source $HOME/install/gromacs-${GROMACS}/bin/GMXRC && (cd /tmp && bash -x ${GITHUB_WORKSPACE}/ci_scripts/pygmx_0_0_7.sh)
-        (cd /tmp && bash -x ${GITHUB_WORKSPACE}/ci_scripts/brer_restraint.sh)
+        source $HOME/install/gromacs-${GROMACS}/bin/GMXRC && bash -x ${GITHUB_WORKSPACE}/ci_scripts/pygmx_0_0_7.sh
+        bash -x ${GITHUB_WORKSPACE}/ci_scripts/brer_restraint.sh
         pwd
         ls
         git tag --list
@@ -65,6 +65,14 @@ jobs:
         versioningit .
         pip install ${GITHUB_WORKSPACE}/
         $PYTHON -m pytest -rA -l --log-cli-level=info --cov=run_brer tests
+    - name: "Upload artifacts"
+      if: failure()
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.job }}-${{ env.GROMACS }}
+        path: |
+          ~/install/
+          ~/gmxapi/build/
 
   gmx2021:
     runs-on: ubuntu-latest
@@ -106,6 +114,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install GROMACS
       run: |
+        . $HOME/venv/bin/activate
         . ${GITHUB_WORKSPACE}/ci_scripts/set_compilers
         BRANCH="${GROMACS}" bash -x ${GITHUB_WORKSPACE}/ci_scripts/install_gromacs_branch.sh
     - name: Test
@@ -115,8 +124,11 @@ jobs:
         . $HOME/venv/bin/activate
         pip install -r requirements.txt
         export PYTHON=$VIRTUAL_ENV/bin/python
-        source $HOME/install/gromacs-${GROMACS}/bin/GMXRC && (cd /tmp && pip install "${{ env.GMXAPI }}")
-        (cd /tmp && bash -x ${GITHUB_WORKSPACE}/ci_scripts/brer_restraint.sh)
+        source $HOME/install/gromacs-${GROMACS}/bin/GMXRC && \
+        mkdir -p $HOME/pip-tmp && \
+        TMPDIR=$HOME/pip-tmp \
+        $PYTHON -m pip install --no-clean --verbose "${{ env.GMXAPI }}"
+        bash -x ${GITHUB_WORKSPACE}/ci_scripts/brer_restraint.sh
         git tag --list
         pip list
         export VERSIONINGIT_LOG_LEVEL=INFO
@@ -124,6 +136,14 @@ jobs:
         $PYTHON -m build
         pip install dist/*whl
         $PYTHON -m pytest -rA -l --log-cli-level=info --cov=run_brer tests
+    - name: "Upload artifacts"
+      if: failure()
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.job }}-${{ env.GROMACS }}
+        path: |
+          ~/install/
+          ~/pip-tmp/
 
   gmx2022:
     runs-on: ubuntu-latest
@@ -158,13 +178,13 @@ jobs:
         . $HOME/venv/bin/activate
         export PYTHON=$VIRTUAL_ENV/bin/python
         $PYTHON -m pip install --upgrade pip setuptools wheel
-        pip install --upgrade pip setuptools wheel
         pip install --upgrade packaging
         pip install --no-cache-dir --upgrade --no-binary ":all:" --force-reinstall networkx mpi4py MarkupSafe
         pip install pytest codecov pytest-cov numpy
     - uses: actions/checkout@v2
     - name: Install GROMACS
       run: |
+        . $HOME/venv/bin/activate
         . ${GITHUB_WORKSPACE}/ci_scripts/set_compilers
         BRANCH="${GROMACS}" bash -x ${GITHUB_WORKSPACE}/ci_scripts/install_gromacs_branch.sh
     - name: Test
@@ -174,8 +194,12 @@ jobs:
         . $HOME/venv/bin/activate
         pip install -r requirements.txt
         export PYTHON=$HOME/venv/bin/python
-        source $HOME/install/gromacs-${GROMACS}/bin/GMXRC && (cd /tmp && pip install "${{ env.GMXAPI }}")
-        (cd /tmp && bash -x ${GITHUB_WORKSPACE}/ci_scripts/brer_restraint.sh)
+        # Temporarily use test.pypi for updated gmxapi 0.3.x
+        source $HOME/install/gromacs-${GROMACS}/bin/GMXRC && \
+        mkdir -p $HOME/pip-tmp && \
+        TMPDIR=$HOME/pip-tmp \
+        $PYTHON -m pip install --no-clean --verbose "${{ env.GMXAPI }}" --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/
+        bash -x ${GITHUB_WORKSPACE}/ci_scripts/brer_restraint.sh
         git tag --list
         pip list
         export VERSIONINGIT_LOG_LEVEL=INFO
@@ -194,3 +218,11 @@ jobs:
         export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
         export GITHUB_REPOSITORY=$GITHUB_REPOSITORY
         bash -x ./ci_scripts/docs/buildsite.sh
+    - name: "Upload artifacts"
+      if: failure()
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.job }}-${{ env.GROMACS }}
+        path: |
+          ~/install/
+          ~/pip-tmp/

--- a/ci_scripts/brer_restraint.sh
+++ b/ci_scripts/brer_restraint.sh
@@ -4,6 +4,7 @@ set -ev
 pushd $HOME
   [ -d brer_plugin ] || git clone --depth=1 https://github.com/kassonlab/brer_plugin.git
   pushd brer_plugin
+    git pull --ff-only
     rm -rf build
     mkdir build
     pushd build

--- a/ci_scripts/install_gromacs_branch.sh
+++ b/ci_scripts/install_gromacs_branch.sh
@@ -21,6 +21,8 @@ pushd $HOME
   rm -rf build
   mkdir build
   pushd build
+   which cmake
+   cmake --version
    cmake -G Ninja \
          -DCMAKE_CXX_COMPILER=$CXX \
          -DGMX_ENABLE_CCACHE=ON \

--- a/ci_scripts/pygmx_0_0_7.sh
+++ b/ci_scripts/pygmx_0_0_7.sh
@@ -2,17 +2,17 @@
 set -ev
 
 pushd $HOME
- [ -d gmxapi ] || git clone --depth=1 --no-single-branch https://github.com/kassonlab/gmxapi.git
+ rm -rf gmxapi
+ git clone --depth=1 -b release-0_0_7 https://github.com/kassonlab/gmxapi.git
  pushd gmxapi
-  git checkout release-0_0_7
   rm -rf build
   mkdir -p build
   pushd build
+   cmake --version
    cmake .. -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC -DPYTHON_EXECUTABLE=$PYTHON
    make -j2 install
   popd
  popd
  mpiexec -n 2 $PYTHON -m mpi4py -m pytest --log-cli-level=WARN --pyargs gmx -s
 # mpiexec -n 2 $PYTHON -m mpi4py -m pytest --log-cli-level=DEBUG --pyargs gmx -s --verbose
- ccache -s
 popd


### PR DESCRIPTION
* Stay out of the runner's /tmp
* Retain more debugging artifacts on failure.
* Normalize some versions and branch access.

Also, temporarily uses PyPI test server for a patched gmxapi release.
(See #62)