### PR TITLE
Stop using PyPI test server for a patched gmxapi release.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -194,11 +194,10 @@ jobs:
         . $HOME/venv/bin/activate
         pip install -r requirements.txt
         export PYTHON=$HOME/venv/bin/python
-        # Temporarily use test.pypi for updated gmxapi 0.3.x
         source $HOME/install/gromacs-${GROMACS}/bin/GMXRC && \
         mkdir -p $HOME/pip-tmp && \
         TMPDIR=$HOME/pip-tmp \
-        $PYTHON -m pip install --no-clean --verbose "${{ env.GMXAPI }}" --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/
+        $PYTHON -m pip install --no-clean --verbose "${{ env.GMXAPI }}"
         bash -x ${GITHUB_WORKSPACE}/ci_scripts/brer_restraint.sh
         git tag --list
         pip list


### PR DESCRIPTION
Main gmxapi release on pypi has the necessary CMake workaround
as of 0.3.2.post1

Ref #62