### PR TITLE
Restore automated codecov reports.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,7 +135,14 @@ jobs:
         versioningit .
         $PYTHON -m build
         pip install dist/*whl
-        $PYTHON -m pytest -rA -l --log-cli-level=info --cov=run_brer tests
+        $PYTHON -m pytest -rA -l --log-cli-level=info --cov=run_brer --cov-report=xml tests
+    - name: "Upload coverage to Codecov"
+      continue-on-error: true
+      uses: codecov/codecov-action@v2
+      with:
+        file: ./coverage.xml
+        fail_ci_if_error: true
+        name: codecov-${{ env.GMXAPI }}-${{ env.GROMACS }}-${{ matrix.python-version }}
     - name: "Upload artifacts"
       if: failure()
       uses: actions/upload-artifact@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,14 @@ jobs:
         export VERSIONINGIT_LOG_LEVEL=INFO
         versioningit .
         pip install ${GITHUB_WORKSPACE}/
-        $PYTHON -m pytest -rA -l --log-cli-level=info --cov=run_brer tests
+        $PYTHON -m pytest -rA -l --log-cli-level=info --cov=run_brer --cov-report=xml tests
+    - name: "Upload coverage to Codecov"
+      continue-on-error: true
+      uses: codecov/codecov-action@v2
+      with:
+        file: ./coverage.xml
+        fail_ci_if_error: true
+        name: codecov-gmx0_0_7-${{ env.GROMACS }}-${{ matrix.python-version }}
     - name: "Upload artifacts"
       if: failure()
       uses: actions/upload-artifact@v3
@@ -212,8 +219,15 @@ jobs:
         versioningit .
         $PYTHON -m build --sdist
         pip install dist/*
-        $PYTHON -m pytest -rA -l --log-cli-level=info --cov=run_brer tests
         echo "github.ref_name: ${{ github.ref_name }}"
+        $PYTHON -m pytest -rA -l --log-cli-level=info --cov=run_brer --cov-report=xml tests
+    - name: "Upload coverage to Codecov"
+      continue-on-error: true
+      uses: codecov/codecov-action@v2
+      with:
+        file: ./coverage.xml
+        fail_ci_if_error: true
+        name: codecov-${{ env.GMXAPI }}-${{ env.GROMACS }}-${{ matrix.python-version }}
     - name: Docs
       if: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
       run: |

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build and test](https://github.com/kassonlab/run_brer/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/kassonlab/run_brer/actions/workflows/test.yml)
 [![Documentation](https://github.com/kassonlab/run_brer/actions/workflows/pages/pages-build-deployment/badge.svg?branch=master)](https://github.com/kassonlab/run_brer/actions/workflows/pages/pages-build-deployment)
+[![codecov](https://codecov.io/gh/kassonlab/run_brer/branch/master/graph/badge.svg)](https://codecov.io/gh/kassonlab/run_brer)
 
 This project is hosted in a git repository at https://github.com/kassonlab/run_brer
 


### PR DESCRIPTION
* Upload codecov reports to the cloud service.
* Add the codecov badge back to our GitHub landing page.

Refs #2.